### PR TITLE
Cleanup logging and allow schema not exist errors to be caught more generically

### DIFF
--- a/db.go
+++ b/db.go
@@ -12,9 +12,9 @@ type DB struct {
 	Driver string
 	DSN    string
 
-	exclusive        sync.Mutex
+	exclusive  sync.Mutex
 	connection *sql.DB
-	cache     map[string]*sql.Stmt
+	cache      map[string]*sql.Stmt
 }
 
 func (db *DB) Copy() *DB {
@@ -118,7 +118,6 @@ func (db *DB) statement(sql string) (*sql.Stmt, error) {
 	}
 
 	log.Debugf("Executing SQL: %s", sql)
-	fmt.Printf("Executing SQL: %s\n", sql)
 
 	q, ok := db.cache[sql]
 	if !ok {

--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 )
 
@@ -56,7 +57,7 @@ func (s *Schema) Current(d *DB) (int, error) {
 		if err.Error() == `pq: relation "schema_info" does not exist` {
 			return 0, nil
 		}
-		if err.Error() == `Error 1146: Table 'optigit.schema_info' doesn't exist` {
+		if match, _ := regexp.MatchString("Error 1146: Table '.*' doesn't exist", err.Error()); match {
 			return 0, nil
 		}
 		return 0, err


### PR DESCRIPTION
- Removes the printf that logs all SQL statements in addition to the debugf
- Allows the schema table not found error to be caught when the DB is not named `optigit`